### PR TITLE
fixed resultDir bug

### DIFF
--- a/dustmite.d
+++ b/dustmite.d
@@ -153,7 +153,7 @@ EOS");
 
 	enforce(!(stripComments && coverageDir), "Sorry, --strip-comments is not compatible with --coverage");
 
-	dir = args[1];
+	dir = args[1].absolutePath().buildNormalizedPath();
 	if (isDirSeparator(dir[$-1]))
 		dir = dir[0..$-1];
 


### PR DESCRIPTION
If the source directory was given as . then the resultDir was wrong. This fixes this.
