### PR TITLE
Fix infinite loop

### DIFF
--- a/splitter.d
+++ b/splitter.d
@@ -830,6 +830,7 @@ struct DSplitter
 				j++; // ; or {
 				if (j <= entities.length)
 					entities = entities[0..i] ~ group(group(entities[i..j-1]) ~ entities[j-1..j]) ~ entities[j..$];
+				i++;
 				continue;
 			}
 


### PR DESCRIPTION
This goes into an infinite loop when `i` is not incremented. It happened while reducing some private D1 code, so I can't give you a test-case sadly. Does this look ok to you now?
