### PR TITLE
Fix implicit conversion of dynamic array to bool

### DIFF
--- a/dustmite.d
+++ b/dustmite.d
@@ -18,6 +18,7 @@ import std.regex;
 import std.conv;
 import std.ascii;
 import std.random;
+import std.range;
 
 import splitter;
 
@@ -177,7 +178,7 @@ EOS");
 		return showHelp ? 0 : 64; // EX_USAGE
 	}
 
-	enforce(!(stripComments && coverageDir !is null), "Sorry, --strip-comments is not compatible with --coverage");
+	enforce(!(stripComments && !coverageDir.empty), "Sorry, --strip-comments is not compatible with --coverage");
 
 	dir = args[1];
 	if (isDirSeparator(dir[$-1]))
@@ -216,7 +217,7 @@ EOS");
 
 	applyNoRemoveMagic();
 	applyNoRemoveRegex(noRemoveStr, reduceOnly);
-	if (coverageDir !is null)
+	if (!coverageDir.empty)
 		loadCoverage(coverageDir);
 	if (!obfuscate && !noOptimize)
 		optimize(root);
@@ -662,10 +663,10 @@ void dump(Entity root, ref Reduction reduction, void delegate(string) handleFile
 					dumpEntity(c);
 			}
 			else
-			if (e.head !is null || e.tail !is null)
+			if (!e.head.empty || !e.tail.empty)
 			{
 				assert(e.children.length==0);
-				if (e.head !is null)
+				if (!e.head.empty)
 				{
 					if (e.head == reduction.from)
 						handleText(reduction.to);
@@ -1030,7 +1031,7 @@ bool test(Reduction reduction)
 	{
 		tests++;
 
-		if (globalCache !is null)
+		if (!globalCache.empty)
 		{
 			if (!exists(globalCache)) mkdirRecurse(globalCache);
 			string cacheBase = absolutePath(buildPath(globalCache, formatHash(digest))) ~ "-";
@@ -1312,20 +1313,20 @@ void dumpSet(string fn)
 				"[",
 				e.noRemove ? "!" : "",
 				" ",
-				e.isFile ? e.filename !is null ? printableFN(e.filename) ~ " " : null : e.head !is null ? printable(e.head) ~ " " : null,
-				e.tail !is null ? printable(e.tail) ~ " " : null,
-				e.comment !is null ? "/* " ~ e.comment ~ " */ " : null,
+				e.isFile ? !e.filename.empty ? printableFN(e.filename) ~ " " : null : !e.head.empty ? printable(e.head) ~ " " : null,
+				!e.tail.empty ? printable(e.tail) ~ " " : null,
+				!e.comment.empty ? "/* " ~ e.comment ~ " */ " : null,
 				"]"
 			);
 		}
 		else
 		{
-			f.writeln("[", e.noRemove ? "!" : "", e.comment !is null ? " // " ~ e.comment : null);
+			f.writeln("[", e.noRemove ? "!" : "", !e.comment.empty ? " // " ~ e.comment : null);
 			if (e.isFile) f.writeln(prefix, "  ", printableFN(e.filename));
-			if (e.head !is null) f.writeln(prefix, "  ", printable(e.head));
+			if (!e.head.empty) f.writeln(prefix, "  ", printable(e.head));
 			foreach (c; e.children)
 				print(c, depth+1);
-			if (e.tail !is null) f.writeln(prefix, "  ", printable(e.tail));
+			if (!e.tail.empty) f.writeln(prefix, "  ", printable(e.tail));
 			f.write(prefix, "]");
 		}
 		if (e.id in dependents || trace)

--- a/dustmite.d
+++ b/dustmite.d
@@ -177,7 +177,7 @@ EOS");
 		return showHelp ? 0 : 64; // EX_USAGE
 	}
 
-	enforce(!(stripComments && coverageDir), "Sorry, --strip-comments is not compatible with --coverage");
+	enforce(!(stripComments && coverageDir !is null), "Sorry, --strip-comments is not compatible with --coverage");
 
 	dir = args[1];
 	if (isDirSeparator(dir[$-1]))
@@ -216,7 +216,7 @@ EOS");
 
 	applyNoRemoveMagic();
 	applyNoRemoveRegex(noRemoveStr, reduceOnly);
-	if (coverageDir)
+	if (coverageDir !is null)
 		loadCoverage(coverageDir);
 	if (!obfuscate && !noOptimize)
 		optimize(root);
@@ -662,10 +662,10 @@ void dump(Entity root, ref Reduction reduction, void delegate(string) handleFile
 					dumpEntity(c);
 			}
 			else
-			if (e.head || e.tail)
+			if (e.head !is null || e.tail !is null)
 			{
 				assert(e.children.length==0);
-				if (e.head)
+				if (e.head !is null)
 				{
 					if (e.head == reduction.from)
 						handleText(reduction.to);
@@ -1030,7 +1030,7 @@ bool test(Reduction reduction)
 	{
 		tests++;
 
-		if (globalCache)
+		if (globalCache !is null)
 		{
 			if (!exists(globalCache)) mkdirRecurse(globalCache);
 			string cacheBase = absolutePath(buildPath(globalCache, formatHash(digest))) ~ "-";
@@ -1312,20 +1312,20 @@ void dumpSet(string fn)
 				"[",
 				e.noRemove ? "!" : "",
 				" ",
-				e.isFile ? e.filename ? printableFN(e.filename) ~ " " : null : e.head ? printable(e.head) ~ " " : null,
-				e.tail ? printable(e.tail) ~ " " : null,
-				e.comment ? "/* " ~ e.comment ~ " */ " : null,
+				e.isFile ? e.filename !is null ? printableFN(e.filename) ~ " " : null : e.head !is null ? printable(e.head) ~ " " : null,
+				e.tail !is null ? printable(e.tail) ~ " " : null,
+				e.comment !is null ? "/* " ~ e.comment ~ " */ " : null,
 				"]"
 			);
 		}
 		else
 		{
-			f.writeln("[", e.noRemove ? "!" : "", e.comment ? " // " ~ e.comment : null);
+			f.writeln("[", e.noRemove ? "!" : "", e.comment !is null ? " // " ~ e.comment : null);
 			if (e.isFile) f.writeln(prefix, "  ", printableFN(e.filename));
-			if (e.head) f.writeln(prefix, "  ", printable(e.head));
+			if (e.head !is null) f.writeln(prefix, "  ", printable(e.head));
 			foreach (c; e.children)
 				print(c, depth+1);
-			if (e.tail) f.writeln(prefix, "  ", printable(e.tail));
+			if (e.tail !is null) f.writeln(prefix, "  ", printable(e.tail));
 			f.write(prefix, "]");
 		}
 		if (e.id in dependents || trace)

--- a/dustmite.d
+++ b/dustmite.d
@@ -18,7 +18,6 @@ import std.regex;
 import std.conv;
 import std.ascii;
 import std.random;
-import std.range;
 
 import splitter;
 
@@ -178,7 +177,7 @@ EOS");
 		return showHelp ? 0 : 64; // EX_USAGE
 	}
 
-	enforce(!(stripComments && !coverageDir.empty), "Sorry, --strip-comments is not compatible with --coverage");
+	enforce(!(stripComments && coverageDir.ptr), "Sorry, --strip-comments is not compatible with --coverage");
 
 	dir = args[1];
 	if (isDirSeparator(dir[$-1]))
@@ -217,7 +216,7 @@ EOS");
 
 	applyNoRemoveMagic();
 	applyNoRemoveRegex(noRemoveStr, reduceOnly);
-	if (!coverageDir.empty)
+	if (coverageDir.ptr)
 		loadCoverage(coverageDir);
 	if (!obfuscate && !noOptimize)
 		optimize(root);
@@ -663,10 +662,10 @@ void dump(Entity root, ref Reduction reduction, void delegate(string) handleFile
 					dumpEntity(c);
 			}
 			else
-			if (!e.head.empty || !e.tail.empty)
+			if (e.head.ptr || e.tail.ptr)
 			{
 				assert(e.children.length==0);
-				if (!e.head.empty)
+				if (e.head.ptr)
 				{
 					if (e.head == reduction.from)
 						handleText(reduction.to);
@@ -1031,7 +1030,7 @@ bool test(Reduction reduction)
 	{
 		tests++;
 
-		if (!globalCache.empty)
+		if (globalCache.ptr)
 		{
 			if (!exists(globalCache)) mkdirRecurse(globalCache);
 			string cacheBase = absolutePath(buildPath(globalCache, formatHash(digest))) ~ "-";
@@ -1313,20 +1312,20 @@ void dumpSet(string fn)
 				"[",
 				e.noRemove ? "!" : "",
 				" ",
-				e.isFile ? !e.filename.empty ? printableFN(e.filename) ~ " " : null : !e.head.empty ? printable(e.head) ~ " " : null,
-				!e.tail.empty ? printable(e.tail) ~ " " : null,
-				!e.comment.empty ? "/* " ~ e.comment ~ " */ " : null,
+				e.isFile ? e.filename.ptr ? printableFN(e.filename) ~ " " : null : e.head.ptr ? printable(e.head) ~ " " : null,
+				e.tail.ptr ? printable(e.tail) ~ " " : null,
+				e.comment.ptr ? "/* " ~ e.comment ~ " */ " : null,
 				"]"
 			);
 		}
 		else
 		{
-			f.writeln("[", e.noRemove ? "!" : "", !e.comment.empty ? " // " ~ e.comment : null);
+			f.writeln("[", e.noRemove ? "!" : "", e.comment.ptr ? " // " ~ e.comment : null);
 			if (e.isFile) f.writeln(prefix, "  ", printableFN(e.filename));
-			if (!e.head.empty) f.writeln(prefix, "  ", printable(e.head));
+			if (e.head.ptr) f.writeln(prefix, "  ", printable(e.head));
 			foreach (c; e.children)
 				print(c, depth+1);
-			if (!e.tail.empty) f.writeln(prefix, "  ", printable(e.tail));
+			if (e.tail.ptr) f.writeln(prefix, "  ", printable(e.tail));
 			f.write(prefix, "]");
 		}
 		if (e.id in dependents || trace)

--- a/splitter.d
+++ b/splitter.d
@@ -514,7 +514,7 @@ struct DSplitter
 					foreach (Token t; Token.init..Token.max)
 					{
 						auto text = tokenText[t];
-						if (text is null)
+						if (text.empty)
 							continue;
 						if (!s[i..$].startsWith(text))
 							continue;
@@ -703,7 +703,7 @@ struct DSplitter
 		reset(code);
 		auto entity = new Entity;
 		parseScope(entity, Token.none);
-		assert(entity.head is null && entity.tail is null);
+		assert(entity.head.empty && entity.tail.empty);
 		postProcess(entity.children);
 		return [entity];
 	}
@@ -724,7 +724,7 @@ struct DSplitter
 			{
 				if (!result.length)
 					result ~= new Entity();
-				if (result[$-1].tail is null)
+				if (result[$-1].tail.empty)
 					result[$-1].tail = span;
 				else
 				{
@@ -793,7 +793,7 @@ struct DSplitter
 
 		size_t[] points;
 		foreach_reverse (i, e; entities[0..$-1])
-			if (getSeparatorType(e.token) == SeparatorType.binary && e.children !is null)
+			if (getSeparatorType(e.token) == SeparatorType.binary && !e.children.empty)
 				points ~= i;
 
 		if (points.length)
@@ -814,7 +814,7 @@ struct DSplitter
 	static void postProcessDependencyBlock(ref Entity[] entities)
 	{
 		foreach (i, e; entities)
-			if (i && !e.token && e.children.length && getSeparatorType(e.children[0].token) == SeparatorType.binary && e.children[0].children is null)
+			if (i && !e.token && e.children.length && getSeparatorType(e.children[0].token) == SeparatorType.binary && e.children[0].children.empty)
 				e.children[0].dependencies ~= entities[i-1];
 	}
 

--- a/splitter.d
+++ b/splitter.d
@@ -514,7 +514,7 @@ struct DSplitter
 					foreach (Token t; Token.init..Token.max)
 					{
 						auto text = tokenText[t];
-						if (text.empty)
+						if (!text.ptr)
 							continue;
 						if (!s[i..$].startsWith(text))
 							continue;
@@ -703,7 +703,7 @@ struct DSplitter
 		reset(code);
 		auto entity = new Entity;
 		parseScope(entity, Token.none);
-		assert(entity.head.empty && entity.tail.empty);
+		assert(!entity.head.ptr && !entity.tail.ptr);
 		postProcess(entity.children);
 		return [entity];
 	}
@@ -724,7 +724,7 @@ struct DSplitter
 			{
 				if (!result.length)
 					result ~= new Entity();
-				if (result[$-1].tail.empty)
+				if (!result[$-1].tail.ptr)
 					result[$-1].tail = span;
 				else
 				{
@@ -793,7 +793,7 @@ struct DSplitter
 
 		size_t[] points;
 		foreach_reverse (i, e; entities[0..$-1])
-			if (getSeparatorType(e.token) == SeparatorType.binary && !e.children.empty)
+			if (getSeparatorType(e.token) == SeparatorType.binary && e.children.ptr)
 				points ~= i;
 
 		if (points.length)
@@ -814,7 +814,7 @@ struct DSplitter
 	static void postProcessDependencyBlock(ref Entity[] entities)
 	{
 		foreach (i, e; entities)
-			if (i && !e.token && e.children.length && getSeparatorType(e.children[0].token) == SeparatorType.binary && e.children[0].children.empty)
+			if (i && !e.token && e.children.length && getSeparatorType(e.children[0].token) == SeparatorType.binary && !e.children[0].children.ptr)
 				e.children[0].dependencies ~= entities[i-1];
 	}
 

--- a/splitter.d
+++ b/splitter.d
@@ -374,24 +374,24 @@ struct DSplitter
 	/// ditto
 	char advance() { return advance(1)[0]; }
 
-	/// If pre comes next, advance i through pre and return it.
-	/// Otherwise, return null.
-	string consume(string pre)
+	/// If pre comes next, advance i through pre and return whether it is not an empty string.
+	/// Otherwise, return false.
+	bool consume(string pre)
 	{
 		if (s[i..$].startsWith(pre))
-			return advance(pre.length);
+			return !advance(pre.length).empty;
 		else
-			return null;
+			return false;
 	}
 
 	/// ditto
-	char consume(char pre)
+	bool consume(char pre)
 	{
 		assert(pre);
 		if (s[i..$].startsWith(pre))
-			return advance();
+			return advance() != 0;
 		else
-			return 0;
+			return false;
 	}
 
 	/// Peeks at the next n characters.
@@ -440,7 +440,7 @@ struct DSplitter
 				advance();
 				break;
 			case 'r':
-				if (consume(`r"`) !is null)
+				if (consume(`r"`))
 				{
 					result = Token.other;
 					while (advance() != '"')
@@ -465,7 +465,7 @@ struct DSplitter
 				if (consume('*'))
 				{
 					result = Token.comment;
-					while (consume("*/") is null)
+					while (!consume("*/"))
 						advance();
 				}
 				else
@@ -475,10 +475,10 @@ struct DSplitter
 					int commentLevel = 1;
 					while (commentLevel)
 					{
-						if (consume("/+") !is null)
+						if (consume("/+"))
 							commentLevel++;
 						else
-						if (consume("+/") !is null)
+						if (consume("+/"))
 							commentLevel--;
 						else
 							advance();
@@ -488,11 +488,11 @@ struct DSplitter
 					goto default;
 				break;
 			case '@':
-				if (consume("disable") !is null
-				 || consume("property") !is null
-				 || consume("safe") !is null
-				 || consume("trusted") !is null
-				 || consume("system") !is null
+				if (consume("disable")
+				 || consume("property")
+				 || consume("safe")
+				 || consume("trusted")
+				 || consume("system")
 				)
 					return Token.other;
 				goto default;
@@ -528,7 +528,7 @@ struct DSplitter
 					if (bestLength)
 					{
 						auto consumed = consume(tokenText[best]);
-						assert(consumed !is null);
+						assert(consumed);
 						return best;
 					}
 

--- a/splitter.d
+++ b/splitter.d
@@ -440,7 +440,7 @@ struct DSplitter
 				advance();
 				break;
 			case 'r':
-				if (consume(`r"`))
+				if (consume(`r"`) !is null)
 				{
 					result = Token.other;
 					while (advance() != '"')
@@ -465,7 +465,7 @@ struct DSplitter
 				if (consume('*'))
 				{
 					result = Token.comment;
-					while (!consume("*/"))
+					while (consume("*/") is null)
 						advance();
 				}
 				else
@@ -475,10 +475,10 @@ struct DSplitter
 					int commentLevel = 1;
 					while (commentLevel)
 					{
-						if (consume("/+"))
+						if (consume("/+") !is null)
 							commentLevel++;
 						else
-						if (consume("+/"))
+						if (consume("+/") !is null)
 							commentLevel--;
 						else
 							advance();
@@ -488,11 +488,11 @@ struct DSplitter
 					goto default;
 				break;
 			case '@':
-				if (consume("disable")
-				 || consume("property")
-				 || consume("safe")
-				 || consume("trusted")
-				 || consume("system")
+				if (consume("disable") !is null
+				 || consume("property") !is null
+				 || consume("safe") !is null
+				 || consume("trusted") !is null
+				 || consume("system") !is null
 				)
 					return Token.other;
 				goto default;
@@ -514,7 +514,7 @@ struct DSplitter
 					foreach (Token t; Token.init..Token.max)
 					{
 						auto text = tokenText[t];
-						if (!text)
+						if (text is null)
 							continue;
 						if (!s[i..$].startsWith(text))
 							continue;
@@ -528,7 +528,7 @@ struct DSplitter
 					if (bestLength)
 					{
 						auto consumed = consume(tokenText[best]);
-						assert(consumed);
+						assert(consumed !is null);
 						return best;
 					}
 
@@ -703,7 +703,7 @@ struct DSplitter
 		reset(code);
 		auto entity = new Entity;
 		parseScope(entity, Token.none);
-		assert(!entity.head && !entity.tail);
+		assert(entity.head is null && entity.tail is null);
 		postProcess(entity.children);
 		return [entity];
 	}
@@ -724,7 +724,7 @@ struct DSplitter
 			{
 				if (!result.length)
 					result ~= new Entity();
-				if (!result[$-1].tail)
+				if (result[$-1].tail is null)
 					result[$-1].tail = span;
 				else
 				{
@@ -793,7 +793,7 @@ struct DSplitter
 
 		size_t[] points;
 		foreach_reverse (i, e; entities[0..$-1])
-			if (getSeparatorType(e.token) == SeparatorType.binary && e.children)
+			if (getSeparatorType(e.token) == SeparatorType.binary && e.children !is null)
 				points ~= i;
 
 		if (points.length)
@@ -814,7 +814,7 @@ struct DSplitter
 	static void postProcessDependencyBlock(ref Entity[] entities)
 	{
 		foreach (i, e; entities)
-			if (i && !e.token && e.children.length && getSeparatorType(e.children[0].token) == SeparatorType.binary && !e.children[0].children)
+			if (i && !e.token && e.children.length && getSeparatorType(e.children[0].token) == SeparatorType.binary && e.children[0].children is null)
 				e.children[0].dependencies ~= entities[i-1];
 	}
 


### PR DESCRIPTION
Here are the messages:
```
dustmite.d(180): Warning: implicit conversion of dynamic arrays to bool can be ambiguous and will be deprecated. Use one of: coverageDir !is null, coverageDir.length, or coverageDir.ptr instead
dustmite.d(180): Warning: implicit conversion of dynamic arrays to bool can be ambiguous and will be deprecated. Use one of: coverageDir !is null, coverageDir.length, or coverageDir.ptr instead
...
```

~~I replaced `arr` with `arr !is null`.~~
~~I replaced `arr` with `!arr.empty` to make consistent with the related request.~~
I replaced `arr` with `arr.ptr` as a conservative fix.

Related: D-Programming-Language/tools#166