### PR TITLE
Fix 'choose a level' assert triggered from pingpong strategy

### DIFF
--- a/dustmite.d
+++ b/dustmite.d
@@ -1153,12 +1153,10 @@ final class PingPongStrategy : LevelStrategy
 		if (!nextInLevel())
 		{
 			// End of level
-			if (levelChanged)
-			{
-				setLevel(currentLevel ? currentLevel - 1 : 0);
-			}
-			else
-			if (!setLevel(currentLevel + 1))
+			immutable nextLevel = (levelChanged)
+				? (currentLevel ? currentLevel - 1 : 0)
+				: currentLevel + 1;
+			if (!setLevel(nextLevel))
 			{
 				if (iterationChanged)
 					nextIteration();


### PR DESCRIPTION
As far as I understand it, `nextIteration` resets the `invalid` state back to false, however this is not called when `levelChanged` in the pingpong strategy.