### PR TITLE
fuzz: Cast allAddresses length to float

### DIFF
--- a/dustmite.d
+++ b/dustmite.d
@@ -1365,7 +1365,7 @@ void fuzz(ref Entity root)
 	{
 		import std.math : log2;
 		auto newRoot = root;
-		auto numReductions = uniform(1, cast(int)log2(allAddresses.length), rng);
+		auto numReductions = uniform(1, cast(int)log2(cast(double)allAddresses.length), rng);
 		Reduction[] reductions;
 		foreach (n; 0 .. numReductions)
 		{


### PR DESCRIPTION
New overloads are coming to the log family (dlang/phobos#8499), you now need to pick which one you mean.

I'm picking double here, as it seems unlikely you'll have an array bigger than 2^^53, but feel free to keep on using the real log2 algorithm if you so wish.
